### PR TITLE
Expose ordering parameters

### DIFF
--- a/manifests/destination.pp
+++ b/manifests/destination.pp
@@ -1,10 +1,10 @@
 define syslog_ng::destination (
-  $params = []
+  $params = [],
+  $order = '70'
 ) {
   $type = 'destination'
   $id = $title
-  $order = '70'
-    
+
   concat::fragment { "syslog_ng::destination ${title}":
     target  => $::syslog_ng::config_file,
     content => generate_statement($id, $type, $params),

--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -1,9 +1,9 @@
 define syslog_ng::filter (
-  $params = []
+  $params = [],
+  $order = '50'
 ) {
   $type = 'filter'
   $id = $title
-  $order = '50'
 
   concat::fragment { "syslog_ng::filter ${title}":
     target  => $::syslog_ng::config_file,

--- a/manifests/log.pp
+++ b/manifests/log.pp
@@ -1,7 +1,7 @@
 define syslog_ng::log (
-  $params = []
-) {
+  $params = [],
   $order = '80'
+) {
   concat::fragment { "syslog_ng::log ${title}":
     target  => $::syslog_ng::config_file,
     content => generate_log($params),

--- a/manifests/options.pp
+++ b/manifests/options.pp
@@ -1,8 +1,7 @@
 define syslog_ng::options (
-  $options = {}
-) {
+  $options = {},
   $order = '10'
-
+) {
   concat::fragment { "syslog_ng::options ${title}":
     target  => $::syslog_ng::config_file,
     content => generate_options($options),

--- a/manifests/parser.pp
+++ b/manifests/parser.pp
@@ -1,10 +1,10 @@
 define syslog_ng::parser (
-  $params = []
+  $params = [],
+  $order = '40'
 ) {
   $type = 'parser'
   $id = $title
-  $order = '40'
-    
+
   concat::fragment { "syslog_ng::parser ${title}":
     target  => $::syslog_ng::config_file,
     content => generate_statement($id, $type, $params),

--- a/manifests/rewrite.pp
+++ b/manifests/rewrite.pp
@@ -1,10 +1,10 @@
 define syslog_ng::rewrite (
-  $params = []
+  $params = [],
+  $order = '30'
 ) {
   $type = 'rewrite'
   $id = $title
-  $order = '30'
-    
+
   concat::fragment { "syslog_ng::rewrite ${title}":
     target  => $::syslog_ng::config_file,
     content => generate_statement($id, $type, $params),

--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -1,12 +1,12 @@
 define syslog_ng::source (
-  $params = []
+  $params = [],
+  $order = '60'
 ) {
   include syslog_ng::params
 
   $type = 'source'
   $id = $title
-  $order = '60'
-    
+
   concat::fragment { "syslog_ng::source ${title}":
     target  => $::syslog_ng::config_file,
       content => generate_statement($id, $type, $params),

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -1,10 +1,10 @@
 define syslog_ng::template (
-  $params = []
+  $params = [],
+  $order = '20'
 ) {
   $type = 'template'
   $id = $title
-  $order = '20'
-    
+
   concat::fragment { "syslog_ng::template ${title}":
     target  => $::syslog_ng::config_file,
     content => generate_statement($id, $type, $params),


### PR DESCRIPTION
For log paths, relative order within the configuration file is important
when mixing final and non-final statements like this:

log { destination(d_archive); }
log { filter(f_some); destination(d_some); flags(final); }
log { destination(d_rest); }

Expose the order parameter for log resources (and while at it for all
resource types) to be able to implement this kind of ordering:

```
syslog_ng::log { 'archive':
	params => [ { 'destination' => 'd_archive' } ],
	order => '79' }
syslog_ng::log { 'some':
	params => [ { 'filter' => 'f_some' },
		{ 'destination' => 'd_some' },
		{ 'flags' => 'final' } ] }
syslog_ng::log { 'rest':
	params => [ { 'destination' => 'd_rest' } ],
	order => '81'}
```